### PR TITLE
Set up build infrastructure and errs package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,17 @@
+name: ci
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-go@v1
+      with:
+        go-version: 1.14
+    - uses: actions/checkout@v2
+    - run: make

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -1,0 +1,18 @@
+name: bump version
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: '0'
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@1.17.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true
+        DEFAULT_BUMP: patch

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage.out

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,43 @@
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - funlen
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godox
+    - gofmt
+    - goimports
+    - golint
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - maligned
+    - misspell
+    - nakedret
+    - prealloc
+    - rowserrcheck
+    - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+# disabled: gomnd wsl

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 the foxygoat authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+all: test check-coverage lint  ## test, check coverage and lint
+	@if [ -e .git/rebase-merge ]; then git --no-pager log -1 --pretty='%h %s'; fi
+	@echo '$(COLOUR_GREEN)Success$(COLOUR_NORMAL)'
+
+clean::  ## Remove generated files
+
+.PHONY: all clean
+
+
+# -- Test ---------------------------------------------------------------------
+
+COVERFILE = coverage.out
+COVERAGE = 100
+
+test:  ## Run tests and generate a coverage file
+	go test -coverprofile=$(COVERFILE) ./...
+
+check-coverage: test  ## Check that test coverage meets the required level
+	@go tool cover -func=$(COVERFILE) | $(CHECK_COVERAGE) || $(FAIL_COVERAGE)
+
+cover: test  ## Show test coverage in your browser
+	go tool cover -html=$(COVERFILE)
+
+clean::
+	rm -f $(COVERFILE)
+
+CHECK_COVERAGE = awk -F '[ \t%]+' '/^total:/ && $$3 < $(COVERAGE) {exit 1}'
+FAIL_COVERAGE = { echo '$(COLOUR_RED)FAIL - Coverage below $(COVERAGE)%$(COLOUR_NORMAL)'; exit 1; }
+
+.PHONY: test check-coverage cover
+
+
+# -- Lint ---------------------------------------------------------------------
+
+GOLINT_VERSION = 1.24.0
+GOLINT_INSTALLED_VERSION = $(or $(word 4,$(shell golangci-lint --version 2>/dev/null)),0.0.0)
+GOLINT_MIN_VERSION = $(shell printf '%s\n' $(GOLINT_VERSION) $(GOLINT_INSTALLED_VERSION) | sort -V | head -n 1)
+
+lint: ## Lint source code
+ifeq ($(GOLINT_MIN_VERSION), $(GOLINT_VERSION))
+	golangci-lint run
+else
+lint: lint-with-docker
+endif
+
+lint-with-docker:
+	docker run --rm -v $(PWD):/src -w /src golangci/golangci-lint:v$(GOLINT_VERSION) golangci-lint run
+
+.PHONY: lint
+
+
+# --- Utilities ---------------------------------------------------------------
+
+COLOUR_NORMAL = $(shell tput sgr0 2>/dev/null)
+COLOUR_RED    = $(shell tput setaf 1 2>/dev/null)
+COLOUR_GREEN  = $(shell tput setaf 2 2>/dev/null)
+COLOUR_WHITE  = $(shell tput setaf 7 2>/dev/null)
+
+help:
+	@awk -F ':.*## ' 'NF == 2 && $$1 ~ /^[A-Za-z0-9_-]+$$/ { printf "$(COLOUR_WHITE)%-30s$(COLOUR_NORMAL)%s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+
+.PHONY: help

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Go Snippets
 
+![CI](https://github.com/foxygoat/s/workflows/ci/badge.svg?branch=master)
+
 Copy these independent snippets or import them as micro packages.
 
 ### Development

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Go Snippets
+
+Copy these independent snippets or import them as micro packages.
+
+### Development
+
+-   Pre-requisites: [go](https://golang.org/doc/go1.14), [golangci-lint](https://github.com/golangci/golangci-lint/releases/tag/v1.24.0), GNU make
+-   Build with `make`
+-   View build options with `make help`

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -1,0 +1,108 @@
+// Package errs provides error wrapping functions that allow an error to
+// wrap multiple other errors. The error wrapping in the Go standard
+// library allows an error to wrap only one error with only one %w
+// format verb in the format string passed to fmt.Errorf and the
+// errors.Unwrap() function that returns only a single error.
+//
+// The error type returned by the functions in this package wraps
+// multiple errors so that errors.Is() and errors.As() can be used to
+// query if that error is any one of the wrapped errors. errors.Unwrap()
+// on errors of that type always returns nil as that function cannot
+// return multiple errors.
+//
+// The error type is not exported so is used through the standard Go
+// error interfaces.
+package errs
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// New takes a variable number of input errors and returns an error that
+// is formatted as the concatenation of the string form of each input
+// error, separated by a colon and space. The returned error wraps each
+// input error.
+//
+// For example New(err1, err2, err3) is formatted as
+//    err1: err2: err3
+func New(errs ...error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	if len(errs) == 1 {
+		return errs[0]
+	}
+	format := strings.Repeat("%v: ", len(errs)-1) + "%v"
+	args := make([]interface{}, len(errs))
+	for i := range errs {
+		args[i] = errs[i]
+	}
+	return Errorf(format, args...)
+}
+
+// Errorf returns an error formatted with a format string and arguments,
+// similar to how fmt.Errorf works. The error returned by Errorf wraps
+// each argument that is an error type unless that error argument is
+// marked with the Nowrap() function. The %w format verb should not be
+// used in the format string.
+func Errorf(format string, args ...interface{}) error {
+	rawArgs := make([]interface{}, len(args))
+	var errs []error
+	for i, arg := range args {
+		if n, ok := arg.(noWrap); ok {
+			arg = n.err
+		} else if e, ok := arg.(error); ok {
+			errs = append(errs, e)
+		}
+		rawArgs[i] = arg
+	}
+	return &multiErr{
+		s:    fmt.Sprintf(format, rawArgs...),
+		errs: errs,
+	}
+}
+
+// NoWrap marks errors not to be wrapped for Errorf.
+func NoWrap(err error) noWrap { //nolint:golint
+	return noWrap{err: err}
+}
+
+type noWrap struct{ err error }
+
+// multiErr contains wrapped errors and a formatted error message.
+type multiErr struct {
+	s    string
+	errs []error
+}
+
+// Error returns multiErr's error message to implement error interface.
+func (e *multiErr) Error() string {
+	return e.s
+}
+
+// Is returns true if any error in multiErr's slice of errors or any
+// error within each errors chain matches the target value, or false if
+// not.
+func (e *multiErr) Is(target error) bool {
+	for _, err := range e.errs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// As finds the first error in multiErr's slice of errors or any error
+// within each error's chain that matches the target type. If such an
+// error is found, target is set to the error value and true is
+// returned. Otherwise false is returned.
+func (e *multiErr) As(target interface{}) bool {
+	for _, err := range e.errs {
+		if errors.As(err, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/errs/errs_test.go
+++ b/errs/errs_test.go
@@ -1,0 +1,86 @@
+package errs
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorfIs(t *testing.T) {
+	err1 := fmt.Errorf("error 1")
+	err2 := fmt.Errorf("error 2")
+	err3 := fmt.Errorf("error 3")
+	err := Errorf("%v: %v", err1, err2)
+
+	require.Equal(t, "error 1: error 2", err.Error())
+	require.True(t, errors.Is(err, err1))
+	require.True(t, errors.Is(err, err2))
+	require.False(t, errors.Is(err, err3))
+}
+
+type errType1 string
+type errType2 string
+type errType3 string
+
+func (e errType1) Error() string { return string(e) }
+func (e errType2) Error() string { return string(e) }
+func (e errType3) Error() string { return string(e) }
+
+func TestErrorfAs(t *testing.T) {
+	err1 := errType1("error 1")
+	err2 := errType2("error 2")
+	err := Errorf("%v: %v", err1, err2)
+
+	require.Equal(t, "error 1: error 2", err.Error())
+	var target1 errType1
+	require.True(t, errors.As(err, &target1))
+	require.Equal(t, err1, target1)
+	var target2 errType2
+	require.True(t, errors.As(err, &target2))
+	require.Equal(t, err2, target2)
+	var target3 errType3
+	require.False(t, errors.As(err, &target3))
+}
+
+func TestUnwrapAlwaysNil(t *testing.T) {
+	err1 := fmt.Errorf("error 1")
+	err := Errorf("wrapping %v", err1)
+
+	require.Equal(t, "wrapping error 1", err.Error())
+	require.True(t, errors.Is(err, err1))
+	require.Nil(t, errors.Unwrap(err))
+}
+
+func TestNoWrap(t *testing.T) {
+	err1 := errType1("error 1")
+	err2 := errType2("error 2")
+	err := Errorf("%v: %v", NoWrap(err1), err2)
+
+	require.Equal(t, "error 1: error 2", err.Error())
+	require.False(t, errors.Is(err, err1))
+	require.True(t, errors.Is(err, err2))
+	var target1 errType1
+	require.False(t, errors.As(err, &target1))
+	var target2 errType2
+	require.True(t, errors.As(err, &target2))
+	require.Equal(t, err2, target2)
+}
+
+func TestNew(t *testing.T) {
+	require.Nil(t, New())
+
+	err1 := errType1("error 1")
+	require.Equal(t, err1, New(err1))
+
+	err2 := errType2("error 2")
+	err := New(err1, err2)
+	require.Error(t, err)
+	require.Equal(t, "error 1: error 2", err.Error())
+
+	err3 := errType2("error 3")
+	err = New(err1, err2, err3)
+	require.Error(t, err)
+	require.Equal(t, "error 1: error 2: error 3", err.Error())
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module foxygo.at/s
+
+go 1.14
+
+require github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Create package `errs` which exports `New` and `Errorf` functions, both
allowing to wrap more than a single error. The newly created error is
query-able with `errors.Is` and `errors.As`.

This extension is particularly useful when tagging an error with  a
sentinel error value _and_ keeping the underlying, causing error.

Create Makefile for test, lint and coverage. Configure golangci-lint in
.golangci.yaml and add coverage.out to .gitignore.

Create basic GitHub action for CI.
It seems that pulling golangci-lint is the slow piece of this build :(.
I've tried using https://github.com/actions-contrib/golangci-lint - but got some version conflicts.

Add README.md, linter config .golangci.yaml, .gitignore.