### PR TITLE
Initialise httpe package

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,7 +10,6 @@ linters:
     - dupl
     - errcheck
     - funlen
-    - gochecknoglobals
     - gochecknoinits
     - gocognit
     - goconst
@@ -42,4 +41,4 @@ linters:
     - unused
     - varcheck
     - whitespace
-# disabled: gomnd wsl
+# disabled: gomnd wsl gochecknoglobals

--- a/httpe/example_httpe_test.go
+++ b/httpe/example_httpe_test.go
@@ -1,0 +1,62 @@
+package httpe_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"foxygo.at/s/httpe"
+)
+
+type User struct {
+	Name string
+	Age  int
+}
+
+var (
+	errInput     = errors.New("input error")
+	errDuplicate = errors.New("duplicate")
+	storage      = map[string]User{}
+)
+
+func handle(w http.ResponseWriter, r *http.Request) error {
+	user := User{}
+	body, _ := ioutil.ReadAll(r.Body)
+	if err := json.Unmarshal(body, &user); err != nil {
+		return errInput
+	}
+	if user.Name == "" || user.Age < 0 {
+		return errInput
+	}
+	if _, ok := storage[user.Name]; ok {
+		return errDuplicate
+	}
+	storage[user.Name] = user
+	return nil
+}
+
+func writeErr(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errInput):
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	case errors.Is(err, errDuplicate):
+		http.Error(w, "duplicate user", http.StatusForbidden)
+	default:
+		http.Error(w, "something went wrong", http.StatusInternalServerError)
+	}
+}
+
+func ExampleHandlerFuncE() {
+	handler := httpe.NewHandlerFunc(handle, writeErr)
+	// http.ListenAndServe(":9090", handler)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/user", strings.NewReader(`{"Name": "truncated...`))
+	handler(w, r)
+	fmt.Printf("%d %s", w.Code, w.Body.String())
+	// output: 400 input error
+}

--- a/httpe/httpe.go
+++ b/httpe/httpe.go
@@ -1,0 +1,75 @@
+// Package httpe holds http server utilities
+package httpe
+
+import (
+	"net/http"
+)
+
+// HandlerE works like an HTTP.Handler with the addition of an error
+// return value. It is intended to be used with ErrWriter which handles
+// the error and turns it into an appropriate http response StatusCode
+// and Body.
+type HandlerE interface {
+	ServeHTTPe(http.ResponseWriter, *http.Request) error
+}
+
+// The HandlerFuncE type is an adapter to allow the use of ordinary
+// functions as HandlerE. If f is a function with the appropriate
+// signature, HandlerFuncE(f) is a HandlerE that calls f.
+type HandlerFuncE func(http.ResponseWriter, *http.Request) error
+
+// ServeHTTPe calls f(w, r) and returns its error.
+func (f HandlerFuncE) ServeHTTPe(w http.ResponseWriter, r *http.Request) error {
+	return f(w, r)
+}
+
+// ErrWriter translates an error into the appropriate http response
+// StatusCode and Body and writes it.
+type ErrWriter interface {
+	WriteErr(http.ResponseWriter, error)
+}
+
+// The ErrWriterFunc type is an adapter to allow the use of ordinary
+// functions as ErrWriter. If f is a function with the appropriate
+// signature, ErrWriterFunc(f) is a ErrWriter that calls f.
+type ErrWriterFunc func(http.ResponseWriter, error)
+
+// WriteErr translates an error into the appropriate http response
+// StatusCode and Body and writes it.
+func (ew ErrWriterFunc) WriteErr(w http.ResponseWriter, err error) {
+	ew(w, err)
+}
+
+// NewHandler creates a new http.HandlerFunc which calls
+// HandlerE.ServeHTTP and if it returns an error calls ErrWriter.Write
+// to create the appropriate response.
+func NewHandler(h HandlerE, ew ErrWriter) http.Handler {
+	f := func(w http.ResponseWriter, r *http.Request) {
+		if err := h.ServeHTTPe(w, r); err != nil {
+			ew.WriteErr(w, err)
+		}
+	}
+	return http.HandlerFunc(f)
+}
+
+// NewHandlerFunc creates a new http.HandlerFunc which calls
+// HandlerFuncE and if it returns an error calls ErrWriterFunc to
+// create the appropriate response.
+func NewHandlerFunc(h HandlerFuncE, ew ErrWriterFunc) http.HandlerFunc { //nolint:interfacer
+	return NewHandler(h, ew).(http.HandlerFunc)
+}
+
+// Chain returns a HandlerE which executes each of the HandlerFuncE
+// parameters sequentially stopping at the first one that returns an
+// error, and returning that error, or nil if none return an error.
+func Chain(he ...HandlerE) HandlerE {
+	f := func(w http.ResponseWriter, r *http.Request) error {
+		for _, h := range he {
+			if err := h.ServeHTTPe(w, r); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return HandlerFuncE(f)
+}

--- a/httpe/httpe_test.go
+++ b/httpe/httpe_test.go
@@ -1,0 +1,67 @@
+package httpe
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"foxygo.at/s/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var errNoPost = fmt.Errorf("no POST method")
+
+type handlerE struct{}
+
+func (*handlerE) ServeHTTPe(w http.ResponseWriter, r *http.Request) error {
+	if r.Method != http.MethodPost {
+		return errNoPost
+	}
+	return nil
+}
+
+func (*handlerE) WriteErr(w http.ResponseWriter, err error) {
+	fmt.Fprint(w, err.Error())
+}
+
+func TestHandler(t *testing.T) {
+	he := &handlerE{}
+	h := NewHandler(he, he)
+	r := &http.Request{Method: http.MethodGet}
+	w := mock.ResponseWriter()
+	h.ServeHTTP(w, r)
+	require.Equal(t, errNoPost.Error(), w.LastBody)
+}
+
+func TestHandlerFunc(t *testing.T) {
+	he := handlerE{}
+	h := NewHandlerFunc(he.ServeHTTPe, he.WriteErr)
+	r := &http.Request{Method: http.MethodGet}
+	w := mock.ResponseWriter()
+	h.ServeHTTP(w, r)
+	require.Equal(t, errNoPost.Error(), w.LastBody)
+}
+
+func TestChain(t *testing.T) {
+	count := 0
+	errHand := fmt.Errorf("error 🤚")
+	goodHandler := HandlerFuncE(func(http.ResponseWriter, *http.Request) error {
+		count++
+		return nil
+	})
+	errorHandler := HandlerFuncE(func(http.ResponseWriter, *http.Request) error {
+		return errHand
+	})
+
+	h := Chain(goodHandler, goodHandler, goodHandler)
+	err := h.ServeHTTPe(mock.ResponseWriter(), &http.Request{})
+	require.NoError(t, err)
+	require.Equal(t, count, 3)
+
+	count = 0
+	h = Chain(goodHandler, errorHandler, goodHandler)
+	err = h.ServeHTTPe(mock.ResponseWriter(), &http.Request{})
+	require.Error(t, err)
+	require.Equal(t, err, errHand)
+	require.Equal(t, count, 1)
+}

--- a/mock/responsewriter.go
+++ b/mock/responsewriter.go
@@ -1,0 +1,46 @@
+// Package mock holds mocking utilities used in tests
+package mock
+
+import (
+	"net/http"
+)
+
+// ResponseWriter returns a responseWriter implementing
+// http.ResponseWriter.
+func ResponseWriter() *responseWriter { //nolint:golint
+	return &responseWriter{}
+}
+
+// responseWriter implements http.ResponseWriter.
+type responseWriter struct {
+	LastBody   string
+	LastStatus int
+	header     http.Header
+	err        error
+}
+
+// Err sets the error value returned by the Write method.
+// Chain it with construction: mock.ResponseWriter().Err(someErr)
+func (r *responseWriter) Err(err error) *responseWriter {
+	r.err = err
+	return r
+}
+
+// Header returns the responseWriters HTTP header.
+func (r *responseWriter) Header() http.Header {
+	if r.header == nil {
+		r.header = http.Header{}
+	}
+	return r.header
+}
+
+// WriteHeader writes HTTP Status code to struct field.
+func (r *responseWriter) WriteHeader(status int) {
+	r.LastStatus = status
+}
+
+// Write writes response body to struct field.
+func (r *responseWriter) Write(b []byte) (int, error) {
+	r.LastBody = string(b)
+	return len(b), r.err
+}


### PR DESCRIPTION
Implement core functionality of httpe package: an http.Handler that can
return an error.

	type HandlerE interface {
	       ServeHTTP(http.ResponseWriter, *http.Request) error
	}

It is intended to be used with ErrWriter which handles the error and
turns it into an appropriate http response StatusCode and Body.

	type ErrWriter interface {
	       Write(http.ResponseWriter, error)
	}

`Chain` chains several `HandlerE`s sequentially and bails on the first
error.

`NewHandler` creates a traditional `http.Handler` from a `HandlerE` and
`ErrWriter` and `NewHandlerFunc` creates an `http.HandlerFunc` from
`HandlerFuncE` and `ErrWriterFunc`.

The httpe package also provides HandlerFuncE and ErrWriterFunc types as
adapters to the interfaces, similar to http.HandlerFunc for http.Handler
interface.

Introduce new `mock` package exposing mock.ResponseWriter which
implements http.ResponseWriter. It captures the bytes and http status
code written and can be preset to respond with an error on Write calls.
