### PR TITLE
Create timex package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module foxygo.at/s
 
 go 1.14
 
-require github.com/stretchr/testify v1.5.1
+require (
+	github.com/stretchr/testify v1.5.1
+	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
+)

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a h1:WXEvlFVvvGxCJLG6REjsT03iWnKLEWinaScsxF2Vm2o=
+golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/timex/example_timex_test.go
+++ b/timex/example_timex_test.go
@@ -1,10 +1,12 @@
 package timex_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"foxygo.at/s/timex"
+	"golang.org/x/sync/errgroup"
 )
 
 func ExampleNewTicker() {
@@ -16,4 +18,27 @@ func ExampleNewTicker() {
 	}
 	fmt.Println("cnt:", cnt)
 	// output: cnt: 2
+}
+
+func ExampleNewTickerWithContext() {
+	cnt := 0
+	f := func() error {
+		cnt++
+		if cnt == 5 {
+			return fmt.Errorf("five")
+		}
+		return nil
+	}
+
+	// errgroup.Group will cancel the context when one of the functions it
+	// calls returns an error
+	g, ctx := errgroup.WithContext(context.Background())
+	ticker := timex.NewTickerWithContext(ctx, 2*time.Millisecond)
+
+	for range ticker.C {
+		g.Go(f)
+	}
+	err := g.Wait()
+	fmt.Println("cnt:", cnt, "err:", err)
+	// output: cnt: 5 err: five
 }

--- a/timex/example_timex_test.go
+++ b/timex/example_timex_test.go
@@ -1,0 +1,19 @@
+package timex_test
+
+import (
+	"fmt"
+	"time"
+
+	"foxygo.at/s/timex"
+)
+
+func ExampleNewTicker() {
+	ticker := timex.NewTicker(2 * time.Millisecond)
+	time.AfterFunc(5*time.Millisecond, ticker.Stop)
+	cnt := 0
+	for range ticker.C {
+		cnt++
+	}
+	fmt.Println("cnt:", cnt)
+	// output: cnt: 2
+}

--- a/timex/timex.go
+++ b/timex/timex.go
@@ -5,6 +5,7 @@
 package timex
 
 import (
+	"context"
 	"time"
 )
 
@@ -67,4 +68,17 @@ func (t *Ticker) Stop() {
 	default:
 		close(t.done)
 	}
+}
+
+// NewTickerWithContext creates a Ticker that stops when the context is
+// cancelled.
+func NewTickerWithContext(ctx context.Context, d time.Duration) *Ticker {
+	t := NewTicker(d)
+	if ctx.Done() != nil {
+		go func() {
+			<-ctx.Done()
+			t.Stop()
+		}()
+	}
+	return t
 }

--- a/timex/timex.go
+++ b/timex/timex.go
@@ -1,0 +1,70 @@
+// Package timex provides stdlib time package related utilities.
+//
+// It exports type Ticker which works like stdlib time.Ticker but closes
+// its channel on stop.
+package timex
+
+import (
+	"time"
+)
+
+// A Ticker holds a channel that delivers 'ticks' of a clock at
+// intervals, similar to time.Ticker from the standard library.
+type Ticker struct {
+	C    <-chan time.Time
+	done chan struct{}
+}
+
+// NewTicker returns a new Ticker containing a channel that will send
+// the time with a period specified by the duration argument, similar to
+// standard library's time.Ticker.
+//
+// NewTicker will panic if the duration is negative.
+//
+// It differs from the standard library Ticker by closing C when
+// Stop() is called, which allows for ranging over C:
+//
+//		for range ticker.C {
+//   		// do something
+//		}
+func NewTicker(d time.Duration) *Ticker {
+	c := make(chan time.Time)
+	done := make(chan struct{})
+	tt := time.NewTicker(d)
+	go func() {
+		for {
+			select {
+			case tick := <-tt.C:
+				c <- tick
+			case <-done:
+				tt.Stop()
+				close(c)
+				return
+			}
+		}
+	}()
+	return &Ticker{C: c, done: done}
+}
+
+// Stop turns off the ticker, closing the ticker channel C, after which
+// no more ticks will be sent. It is safe to call Stop more than once;
+// subsequent calls to Stop do nothing.
+//
+// When working with select avoid erroneous ticks on close with:
+// 		for {
+// 		    select {
+// 		    case _, ok := <-ticker.C:
+// 		        if ok {
+// 		            // do something
+// 		        } else {
+// 		            return
+// 		        }
+// 		    }
+// 		}
+func (t *Ticker) Stop() {
+	select {
+	case <-t.done:
+	default:
+		close(t.done)
+	}
+}

--- a/timex/timex_test.go
+++ b/timex/timex_test.go
@@ -1,0 +1,23 @@
+package timex
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTicker(t *testing.T) {
+	ticker := NewTicker(2 * time.Millisecond)
+	time.AfterFunc(5*time.Millisecond, ticker.Stop)
+	cnt := 0
+	for range ticker.C {
+		cnt++
+	}
+	// May be flaky due to OS scheduling
+	require.Equal(t, 2, cnt)
+}
+
+func TestTickerPanic(t *testing.T) {
+	require.Panics(t, func() { NewTicker(-2 * time.Millisecond) })
+}


### PR DESCRIPTION
Create package timex with type Ticker. A Ticker that holds a channel
that delivers 'ticks' of a clock at intervals, similar to time.Ticker
from the standard library.

It differs from the standard library Ticker by closing C when
Stop() is called, which allows for ranging over C:

    for range ticker.C {
            // do something
    }

Add creation functions:
- `NewTicker(d time.Duration)` 
- `NewTickerWithContext(d time.Duration)` 

`NewTickerWithContext` stops when the context gets cancelled.