### PR TITLE
Improve flaky timex test

### DIFF
--- a/timex/example_timex_test.go
+++ b/timex/example_timex_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func ExampleNewTicker() {
-	ticker := timex.NewTicker(2 * time.Millisecond)
-	time.AfterFunc(5*time.Millisecond, ticker.Stop)
+	ticker := timex.NewTicker(20 * time.Millisecond)
+	time.AfterFunc(50*time.Millisecond, ticker.Stop)
 	cnt := 0
 	for range ticker.C {
 		cnt++

--- a/timex/timex_test.go
+++ b/timex/timex_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestTicker(t *testing.T) {
-	ticker := NewTicker(2 * time.Millisecond)
-	time.AfterFunc(5*time.Millisecond, ticker.Stop)
+	ticker := NewTicker(20 * time.Millisecond)
+	time.AfterFunc(50*time.Millisecond, ticker.Stop)
 	cnt := 0
 	for range ticker.C {
 		cnt++


### PR DESCRIPTION
Improve flaky test by increasing the time slices we work with for
single to double digit milli seconds.

Let's hope Cam isn't right _again_.