### PR TITLE
str: Add ToCamelCase function

### DIFF
--- a/str/camel.go
+++ b/str/camel.go
@@ -2,6 +2,7 @@
 package str
 
 import (
+	"strings"
 	"unicode"
 	"unicode/utf8"
 )
@@ -81,4 +82,18 @@ func addWord(words []string, runes []rune) []string {
 		words = append(words, string(runes))
 	}
 	return words
+}
+
+// ToCamelCase converts a string to lower camel case (as used for unexported Go
+// indentifiers), converting the entire first word to lowercase. The word
+// boundaries are located as per CamelSplit. For example, "HelloWorld" becomes
+// "helloWorld", "HTTPDir" becomes "httpDir". If the string contains invalid
+// utf-8, the result is undefined.
+func ToCamelCase(s string) string {
+	splits := CamelSplit(s)
+	if len(splits) == 0 {
+		return ""
+	}
+	splits[0] = strings.ToLower(splits[0])
+	return strings.Join(splits, "")
 }

--- a/str/camel_test.go
+++ b/str/camel_test.go
@@ -37,3 +37,24 @@ func TestCameSplit(t *testing.T) {
 		})
 	}
 }
+
+func TestToCamelCase(t *testing.T) {
+	testCases := map[string]struct {
+		in   string
+		want string
+	}{
+		"empty":   {in: "", want: ""},
+		"single":  {in: "X", want: "x"},
+		"double":  {in: "XX", want: "xx"},
+		"camel":   {in: "camelCase", want: "camelCase"},
+		"pascal":  {in: "PascalCase", want: "pascalCase"},
+		"acronym": {in: "HTTPServer", want: "httpServer"},
+	}
+	for name, tc := range testCases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			got := ToCamelCase(tc.in)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Add `ToCamelCase` to convert a string to lower camel case for
identifiers, making the first word of the identifier lowercase.

Rename the file `str.go` to `camel.go` since it is becoming about camel
case functions. Rename `str_test.go` to `camel_test.go` as appropriate.