### PR TITLE
cmds: Add retry and timeout commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # --- Global -------------------------------------------------------------------
 O = out
 
-all: test cover lint  ## test, check coverage and lint
+all: build test cover lint  ## test, check coverage and lint
 	@if [ -e .git/rebase-merge ]; then git --no-pager log -1 --pretty='%h %s'; fi
 	@echo '$(COLOUR_GREEN)Success$(COLOUR_NORMAL)'
 
@@ -9,6 +9,18 @@ clean::  ## Remove generated files
 	-rm -rf $O
 
 .PHONY: all clean
+
+# --- Build --------------------------------------------------------------------
+# Build all subdirs of ./cmd, excluding those with a leading underscore.
+CMDDIRS = $(filter-out ./cmd/_%,$(wildcard ./cmd/*))
+
+build: | $O  ## Build binaries of directories in ./cmd to out/
+	go build -o $O $(CMDDIRS)
+
+install:  ## Build and install binaries in $GOBIN or $GOPATH/bin
+	go install $(CMDDIRS)
+
+.PHONY: build install
 
 # --- Test ---------------------------------------------------------------------
 COVERFILE = out/coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,34 @@
-all: test check-coverage lint  ## test, check coverage and lint
+# --- Global -------------------------------------------------------------------
+O = out
+
+all: test cover lint  ## test, check coverage and lint
 	@if [ -e .git/rebase-merge ]; then git --no-pager log -1 --pretty='%h %s'; fi
 	@echo '$(COLOUR_GREEN)Success$(COLOUR_NORMAL)'
 
 clean::  ## Remove generated files
+	-rm -rf $O
 
 .PHONY: all clean
 
-# --- Test ---
-
-COVERFILE = coverage.out
+# --- Test ---------------------------------------------------------------------
+COVERFILE = out/coverage.txt
 COVERAGE = 100
 
-test:  ## Run tests and generate a coverage file
+test: | $O  ## Run tests and generate a coverage file
 	go test -coverprofile=$(COVERFILE) ./...
 
-check-coverage: test  ## Check that test coverage meets the required level
+cover: test  ## Check that test coverage meets the required level
 	@go tool cover -func=$(COVERFILE) | $(CHECK_COVERAGE) || $(FAIL_COVERAGE)
 
-cover: test  ## Show test coverage in your browser
+showcover: test  ## Show test coverage in your browser
 	go tool cover -html=$(COVERFILE)
-
-clean::
-	rm -f $(COVERFILE)
 
 CHECK_COVERAGE = awk -F '[ \t%]+' '/^total:/ {print; if ($$3 < $(COVERAGE)) exit 1}'
 FAIL_COVERAGE = { echo '$(COLOUR_RED)FAIL - Coverage below $(COVERAGE)%$(COLOUR_NORMAL)'; exit 1; }
 
-.PHONY: test check-coverage cover
+.PHONY: test cover showcover
 
-# --- Lint ---
-
+# --- Lint ---------------------------------------------------------------------
 GOLINT_VERSION = 1.26.0
 GOLINT_INSTALLED_VERSION = $(or $(word 4,$(shell golangci-lint --version 2>/dev/null)),0.0.0)
 GOLINT_MIN_VERSION = $(shell printf '%s\n' $(GOLINT_VERSION) $(GOLINT_INSTALLED_VERSION) | sort -V | head -n 1)
@@ -46,8 +45,7 @@ lint-with-docker:
 
 .PHONY: lint lint-with-docker
 
-# --- Utilities ---
-
+# --- Utilities ----------------------------------------------------------------
 COLOUR_NORMAL = $(shell tput sgr0 2>/dev/null)
 COLOUR_RED    = $(shell tput setaf 1 2>/dev/null)
 COLOUR_GREEN  = $(shell tput setaf 2 2>/dev/null)
@@ -55,5 +53,8 @@ COLOUR_WHITE  = $(shell tput setaf 7 2>/dev/null)
 
 help:
 	@awk -F ':.*## ' 'NF == 2 && $$1 ~ /^[A-Za-z0-9_-]+$$/ { printf "$(COLOUR_WHITE)%-30s$(COLOUR_NORMAL)%s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+
+$O:
+	@mkdir -p $@
 
 .PHONY: help

--- a/cmd/retry/retry.go
+++ b/cmd/retry/retry.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+func main() {
+	code, err := retry(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	os.Exit(code)
+}
+
+func retry(args []string) (int, error) {
+	if len(args) < 2 {
+		return 1, errors.New("usage: retry <count> command [args...]")
+	}
+	i, err := strconv.Atoi(args[0])
+	if err != nil {
+		return 1, fmt.Errorf("invalid count: %v", err)
+	}
+	return Retry(i, args[1:]...)
+}
+
+// Retry runs a command up to count+1 times (once plus count retries). If the
+// command could not be run or it exits with a non-zero error code, then the
+// command is retried up to count times. The command's exit code and an error
+// (if any) is returned.
+func Retry(count int, argv ...string) (int, error) {
+	err := errors.New("negative retries are not allowed")
+	var cmd *exec.Cmd
+	for i := 0; i <= count && err != nil; i++ {
+		cmd = exec.Command(argv[0], argv[1:]...) //nolint:gosec
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+		err = cmd.Run()
+	}
+	var e *exec.ExitError
+	if err != nil && !errors.As(err, &e) {
+		return 1, err
+	}
+	return cmd.ProcessState.ExitCode(), nil
+}

--- a/cmd/timeout/timeout.go
+++ b/cmd/timeout/timeout.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+func main() {
+	code, err := timeout(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+	}
+	os.Exit(code)
+}
+
+func timeout(args []string) (int, error) {
+	if len(args) < 2 {
+		return 1, errors.New("usage: timeout <duration> command [args...]")
+	}
+	d, err := time.ParseDuration(args[0])
+	if err != nil {
+		return 1, fmt.Errorf("invalid duration: %v", err)
+	}
+	return Timeout(d, args[1:]...)
+}
+
+// Timeout runs a command, killing it after a given duration. The command's
+// exit code and an error (if any) are returned. If the command could not be
+// run, or the timeout expires, the exit code returned is 1.
+func Timeout(d time.Duration, argv ...string) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), d)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...) //nolint:gosec
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	err := cmd.Run()
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return 1, fmt.Errorf("timeout (%s)", d)
+	}
+	var e *exec.ExitError
+	if err != nil && !errors.As(err, &e) {
+		return 1, err
+	}
+	return cmd.ProcessState.ExitCode(), nil
+}


### PR DESCRIPTION
Add a couple of small snippet commands for chaining on the command line to
run commands with a timeout and to retry commands if they fail.

They chain to timeout and retry a dodgy command:

retry 2 timeout 5s dodgy-command args

Update the Makefile with a build section.

Update the Makefile to use the latest form we have settled on, with an
`out/` directory for generated output and style changes to section markers.