### PR TITLE
timeout: Don't kill with SIGKILL on timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-coverage.out
+/out/

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,9 @@ install:  ## Build and install binaries in $GOBIN or $GOPATH/bin
 COVERFILE = out/coverage.txt
 COVERAGE = 100
 
-test: | $O  ## Run tests and generate a coverage file
+test: build | $O  ## Run tests and generate a coverage file
 	go test -coverprofile=$(COVERFILE) ./...
+	./cmd/timeout/test.sh
 
 cover: test  ## Check that test coverage meets the required level
 	@go tool cover -func=$(COVERFILE) | $(CHECK_COVERAGE) || $(FAIL_COVERAGE)

--- a/cmd/timeout/test.sh
+++ b/cmd/timeout/test.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+test_count=0
+fail_count=0
+
+main() {
+  binary="${1:-./out/timeout}"
+  if [[ ! -x "${binary}" ]]; then
+    printf 'FAIL: binary '%s' not found\n' "${binary}"
+    exit 1
+  fi
+
+  # Test: Process exits on signal after timeout (1 second)
+  run_test 1 1 "${binary}" 1s sleep 5
+
+  # Test: Process ignores signal, killed after grace after timeout (1 + 1 seconds)
+  # Note we use SIGCHLD because that is ignored by default
+  run_test 2 1 "${binary}" -s "$(kill -l CHLD)" -g 1s 1s sleep 5
+
+  # Test: Process exits successfully before timeout
+  run_test 0 0 "${binary}" 1s true
+
+  # Test: Process exits unsuccessfully before timeout
+  run_test 0 2 "${binary}" 1s sh -c 'exit 2'
+
+  # Test: Command with slash that exists
+  run_test 0 0 "${binary}" 1s /bin/true
+
+  # Test: Command with slash that does not exist
+  run_test 0 1 "${binary}" 1s /bin/non-existent
+
+  # Test: Command without slash that does not exist
+  run_test 0 1 "${binary}" 1s non-existent
+
+  # TODO(camh): Test stdin/out/err are preserved
+
+  if (( fail_count > 0 )); then
+    printf 'FAIL\t%s : %s/%s tests failed\n' "$0" "${fail_count}" "${test_count}"
+    exit 1
+  fi
+
+  printf 'ok\t%s\n' "$0"
+}
+
+run_test() {
+  (( test_count++ ))
+  run "$@" || (( fail_count++ ))
+}
+
+run() {
+  # Set TIMEFORMAT to show only real time (elapsed) and no decimal places.
+  # From testing this truncates. Since all our tests run in very close to
+  # the second boundary, this gives us a little leeway when running under
+  # load, but it does mean we cannot accurately test the timeout period.
+  local TIMEFORMAT='%0R'
+
+  expected_duration="$1"; shift
+  expected_exit="$1"; shift
+
+  # Discard output of command. Just capture the elapsed time, which needs
+  # the braces to the redirection binds to `time`, not the command.
+  actual_duration=$({ time "$@" >/dev/null 2>&1; } 2>&1)
+  actual_exit=$?
+
+  if (( expected_exit != actual_exit )); then
+    printf -- '--- FAIL: %s\n    exit code mismatch: expected %d, actual %d\n' \
+      "$*" "${expected_exit}" "${actual_exit}"
+    return 1
+  fi
+
+  if (( expected_duration != actual_duration )); then
+    printf -- '--- FAIL: %s\n    duration mismatch: expected %d, actual %d\n' \
+      "$*" "${expected_duration}" "${actual_duration}"
+    return 1
+  fi
+
+  return 0
+}
+
+main "$@"

--- a/cmd/timeout/timeout.go
+++ b/cmd/timeout/timeout.go
@@ -3,14 +3,22 @@ package main
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
 	"time"
 )
 
+var (
+	grace = flag.Duration("g", 3*time.Second, "Grace period before sending SIGKILL")
+	sig   = flag.Int("s", int(syscall.SIGTERM), "Signal to send on timeout")
+)
+
 func main() {
-	code, err := timeout(os.Args[1:])
+	flag.Parse()
+	code, err := timeout(flag.Args())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 	}
@@ -28,21 +36,49 @@ func timeout(args []string) (int, error) {
 	return Timeout(d, args[1:]...)
 }
 
-// Timeout runs a command, killing it after a given duration. The command's
-// exit code and an error (if any) are returned. If the command could not be
-// run, or the timeout expires, the exit code returned is 1.
+// Timeout runs a command, signalling it after a given duration. If the process
+// has not exited by the time the grace period passes, the process is killed.
+// The command's exit code and an error (if any) are returned. If the command
+// could not be run, or the timeout expires, the exit code returned is 1.
 func Timeout(d time.Duration, argv ...string) (int, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), d)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...) //nolint:gosec
-	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
-	err := cmd.Run()
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return 1, fmt.Errorf("timeout (%s)", d)
-	}
-	var e *exec.ExitError
-	if err != nil && !errors.As(err, &e) {
+	cmd, err := exec.LookPath(argv[0])
+	if err != nil {
 		return 1, err
 	}
-	return cmd.ProcessState.ExitCode(), nil
+	// Prevent stdin, stdout and stderr from being closed by StartProcess
+	attr := &os.ProcAttr{Files: []*os.File{os.Stdin, os.Stdout, os.Stderr}}
+	p, err := os.StartProcess(cmd, argv, attr)
+	if err != nil {
+		return 1, err
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	isTimeout := make(chan bool)
+	go func() {
+		timedOut := callAfter(ctx, d, func() { _ = p.Signal(syscall.Signal(*sig)) })
+		if timedOut {
+			callAfter(ctx, *grace, func() { _ = p.Kill() })
+		}
+		isTimeout <- timedOut
+	}()
+	ps, err := p.Wait()
+	cancel()
+	if <-isTimeout {
+		return 1, fmt.Errorf("timeout (%s)", d)
+	}
+	if err != nil {
+		return 1, err
+	}
+	return ps.ExitCode(), nil
+}
+
+// callAfter calls function f after duration d and returns true. If the context
+// is cancelled before duration d, return false without invoking f.
+func callAfter(ctx context.Context, d time.Duration, f func()) bool {
+	select {
+	case <-time.After(d):
+		f()
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }


### PR DESCRIPTION
The original version of `timeout` used a context with a timeout to have
`exec.Cmd` kill the running command. However, that uses `SIGKILL` which
does not give the child process a chance to clean up. In the case where
this was used, `gcloud` had forked a child process. When the parent was
killed with `SIGKILL` it was not able to clean up the child.

Now `SIGTERM` is sent and if the process has not exited within a given
grace period (3s by default), then it is killed with `SIGKILL`. The signal
and grace period can be set with `-s` and `-g` respectively.

Also, fix up `.gitignore` while we're here.