### PR TITLE
test: Add some environment test helpers

### DIFF
--- a/test/doc.go
+++ b/test/doc.go
@@ -1,0 +1,4 @@
+// Package test includes small test helpers, as is appropriate for this
+// snippets module. It is envisaged that it may well outgrow this module at
+// which point it will move to foxygo.at/test.
+package test

--- a/test/env.go
+++ b/test/env.go
@@ -1,0 +1,95 @@
+package test
+
+import (
+	"fmt"
+	"os"
+)
+
+// Environ is a frontend to the OS environment that keeps track of the previous
+// value of an environment variable before setting or unsetting it. Later,
+// Restore() can be called to reset all modified variables back to their
+// original values and their presence.
+//
+// It is intended to be used in test cases where a particular starting
+// environment is needed and to ensure that it is reset back to the starting
+// state at the end.
+//
+// The operations on Environ are not concurrency-safe as the global OS
+// environment is also not concurrency-safe. You should not use Environ in test
+// functions that are marked t.Parallel().
+//
+// The methods on Environ return the receiver so environment setup can be
+// chained:
+//
+//     e := test.Environ{}.Set("FOO", "BAR").Unset("BAZ")
+//     defer e.Restore()
+type Environ map[string]*string
+
+// Env is a global Environ variable for simpler use. Since the OS environment
+// is global, using a global test.Environ is rarely a problem. Use is as
+// simple as:
+//
+//     func TestFoo(t *testing.T) {
+//         test.Env.Set("FOO", "BAR").Unset("BAZ")
+//         defer test.Env.Restore()
+//         ... test, test, test ...
+//     }
+var Env Environ
+
+// Set sets key to value in the OS environment, saving the previous value and
+// presence. It returns the receiver so calls can easily be chained.
+// If key or value are invalid (as per os.Setenv), this method will panic.
+func (e Environ) Set(key, value string) Environ {
+	e.save(key)
+	set(key, value)
+	return e
+}
+
+// Unset removes key from the OS environment, saving the previous value and
+// presence. It returns the receive so calls can easily be chained. If
+// os.Unsetenv returns an error, this method will panic. However, it appears
+// that os.Unsetenv does not return an error.
+func (e Environ) Unset(key string) Environ {
+	e.save(key)
+	unset(key)
+	return e
+}
+
+// Restore restores all the saved values from Set and Unset back to the
+// original values and presence. When Restore returns, all saved values will be
+// forgotten. This permits the Environ to be reused. If Restore is unable to
+// set or unset any variables back to their original state, it will panic.
+func (e Environ) Restore() {
+	for key, value := range e {
+		if value == nil {
+			unset(key)
+		} else {
+			set(key, *value)
+		}
+		delete(e, key)
+	}
+}
+
+func set(key, value string) {
+	if err := os.Setenv(key, value); err != nil {
+		panic(fmt.Errorf("could not Setenv(%#v, %#v): %v", key, value, err))
+	}
+}
+
+func unset(key string) {
+	_ = os.Unsetenv(key)
+	// os.Unsetenv never actually returns an error. Comment this out for coverage.
+	/*
+		if err != nil {
+			panic(fmt.Errorf("could not Unsetenv(%#v): %v", key, err))
+		}
+	*/
+}
+
+func (e Environ) save(key string) {
+	var old *string
+	if v, ok := os.LookupEnv(key); ok {
+		old = &v
+	}
+	e[key] = old
+}

--- a/test/env_test.go
+++ b/test/env_test.go
@@ -1,0 +1,83 @@
+package test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetExisting(t *testing.T) {
+	err := os.Setenv("FOO", "BAR")
+	require.NoError(t, err)
+
+	e := Environ{}
+	e2 := e.Set("FOO", "BAZ")
+	require.Equal(t, e, e2)
+
+	val, ok := os.LookupEnv("FOO")
+	require.True(t, ok, "env var not found in environment: FOO")
+	require.Equal(t, "BAZ", val)
+
+	e.Restore()
+	val, ok = os.LookupEnv("FOO")
+	require.True(t, ok, "env var not found in environment: FOO")
+	require.Equal(t, "BAR", val)
+}
+
+func TestSetNew(t *testing.T) {
+	err := os.Unsetenv("FOO")
+	require.NoError(t, err)
+
+	e := Environ{}
+	e2 := e.Set("FOO", "BAZ")
+	require.Equal(t, e, e2)
+
+	val, ok := os.LookupEnv("FOO")
+	require.True(t, ok, "env var not found in environment: FOO")
+	require.Equal(t, "BAZ", val)
+
+	e.Restore()
+	_, ok = os.LookupEnv("FOO")
+	require.False(t, ok, "env var found in environment: FOO")
+}
+
+func TestSetPanic(t *testing.T) {
+	e := Environ{}
+	require.Panics(t, func() { e.Set("FOO=", "BAR") })
+	require.Panics(t, func() { e.Set("FOO\x00", "BAR") })
+	require.Panics(t, func() { e.Set("FOO", "BAR\x00") })
+}
+
+func TestUnsetExisting(t *testing.T) {
+	err := os.Setenv("FOO", "BAR")
+	require.NoError(t, err)
+
+	e := Environ{}
+	e2 := e.Unset("FOO")
+	require.Equal(t, e, e2)
+
+	_, ok := os.LookupEnv("FOO")
+	require.False(t, ok, "env var found in environment: FOO")
+
+	e.Restore()
+	val, ok := os.LookupEnv("FOO")
+	require.True(t, ok, "env var not found in environment: FOO")
+	require.Equal(t, "BAR", val)
+}
+
+func TestUnsetMissing(t *testing.T) {
+	err := os.Unsetenv("FOO")
+	require.NoError(t, err)
+
+	e := Environ{}
+	e2 := e.Unset("FOO")
+	require.Equal(t, e, e2)
+
+	_, ok := os.LookupEnv("FOO")
+	require.False(t, ok, "env var found in environment: FOO")
+
+	e.Restore()
+	_, ok = os.LookupEnv("FOO")
+	require.False(t, ok, "env var found in environment: FOO")
+}


### PR DESCRIPTION
Add some helpers for setting up the OS environment in tests and
restoring it after the test is done.

A type `test.Environ` is added that can set and unset the OS
environment, keeping a record of what changes it makes. At the end of a
test, the `Restore()` method can be called to return the environment
back to the starting state.

A global variable `test.Env` is provided for simplicity as the OS
environment itself is global, it is not usually necessary to instantiate
the `test.Environ` struct.