### PR TITLE
Setup dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Create dependabot.yaml for a basic set up to automatically check daily on go.mod dependencies.
Follow documentation at
https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates