### PR TITLE
github: Tweak dependabot setup

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,8 +3,12 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+    commit-message:
+      prefix: "deps"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+    commit-message:
+      prefix: "deps"


### PR DESCRIPTION
- Run dependabot monthly instead of daily.
- Change commit prefix from 'build(deps)' to 'deps'.