### PR TITLE
test: Initialise global Env map

### DIFF
--- a/test/env.go
+++ b/test/env.go
@@ -34,7 +34,7 @@ type Environ map[string]*string
 //         defer test.Env.Restore()
 //         ... test, test, test ...
 //     }
-var Env Environ
+var Env = Environ{}
 
 // Set sets key to value in the OS environment, saving the previous value and
 // presence. It returns the receiver so calls can easily be chained.

--- a/test/env_test.go
+++ b/test/env_test.go
@@ -81,3 +81,17 @@ func TestUnsetMissing(t *testing.T) {
 	_, ok = os.LookupEnv("FOO")
 	require.False(t, ok, "env var found in environment: FOO")
 }
+
+func TestGlobalEnv(t *testing.T) {
+	err := os.Unsetenv("FOO")
+	require.NoError(t, err)
+
+	Env.Set("FOO", "BAR")
+	val, ok := os.LookupEnv("FOO")
+	require.True(t, ok, "env var not found in environment: FOO")
+	require.Equal(t, "BAR", val)
+
+	Env.Restore()
+	_, ok = os.LookupEnv("FOO")
+	require.False(t, ok, "env var found in environment: FOO")
+}


### PR DESCRIPTION
The global Env map was not initialised/made. This causes a panic when
trying to use it as documented. Add an intitialiser for it.