### PR TITLE
ci: Update pkg.go.dev on version bump

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -16,3 +16,12 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
         DEFAULT_BUMP: patch
+    # Get the latest module version so pkg.go.dev updates
+    - uses: actions/setup-go@v2.1.1
+      with:
+        go-version: 1.14
+    - name: Update pkg.go.dev
+      env:
+        GO111MODULE: on
+      working-directory: /tmp
+      run: go get foxygo.at/s@latest


### PR DESCRIPTION
When bumping the version of the module (creating the tag), use `go get`
to pull the version via the standard Go proxy so that the docs at
pkg.go.dev get updated.