### PR TITLE
ci: Fix pkg.go.dev tag pull

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -11,6 +11,7 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Bump version and push tag
+      id: bump_version
       uses: anothrNick/github-tag-action@1.23.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -24,4 +25,4 @@ jobs:
       env:
         GO111MODULE: on
       working-directory: /tmp
-      run: go get foxygo.at/s@latest
+      run: go get foxygo.at/s@${{ steps.bump_version.outputs.tag }}


### PR DESCRIPTION
The previous commit added a step to the version bump to `go get` @latest
of the Go module so it will appear in the docs at pkg.go.dev. But it
seemed to get the old version with @latest, so use the tag just set
explicitly and see if that works, of if there is a race condition with
github setting the tag and fetching the latest tag.