### PR TITLE
httpe: Unify NewHandler/NewSafeHandler with options

### DIFF
--- a/httpe/example_httpe_test.go
+++ b/httpe/example_httpe_test.go
@@ -23,6 +23,21 @@ var (
 	storage      = map[string]User{}
 )
 
+func ExampleHandlerFuncE() {
+	// Create a http.HandlerFunc from our httpe.HandlerFuncE function and
+	// an httpe.ErrWriterFunc function.
+	handler := httpe.NewHandlerFunc(handle, httpe.WithErrWriterFunc(writeErr))
+
+	// In this example, we call the handler directly using httptest.
+	// Normally you would start a http server.
+	// http.ListenAndServe(":9090", handler)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/user", strings.NewReader(`{"Name": "truncated...`))
+	handler(w, r)
+	fmt.Printf("%d %s", w.Code, w.Body.String())
+	// output: 400 input error
+}
+
 func handle(w http.ResponseWriter, r *http.Request) error {
 	user := User{}
 	body, _ := ioutil.ReadAll(r.Body)
@@ -48,15 +63,4 @@ func writeErr(w http.ResponseWriter, err error) {
 	default:
 		http.Error(w, "something went wrong", http.StatusInternalServerError)
 	}
-}
-
-func ExampleHandlerFuncE() {
-	handler := httpe.NewHandlerFunc(handle, writeErr)
-	// http.ListenAndServe(":9090", handler)
-
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest("POST", "/user", strings.NewReader(`{"Name": "truncated...`))
-	handler(w, r)
-	fmt.Printf("%d %s", w.Code, w.Body.String())
-	// output: 400 input error
 }

--- a/httpe/httpe.go
+++ b/httpe/httpe.go
@@ -1,14 +1,35 @@
-// Package httpe provides http server utilities.
+// Package httpe provides a model of HTTP handler that returns errors.
+//
+// net/http provides a Handler interface that requires the handler to write
+// errors to the provided ResponseWriter. This is different to the usual Go way
+// of handling errors that has functions returning errors, and it makes normal
+// http.Handlers a bit cumbersome.
+//
+// This package provides a HandlerE interface with a ServeHTTPe method that has
+// the same signature as http.Handler.ServeHTTP except it also returns an
+// error. A separate error handler can be bound to the HandlerE using
+// NewHandler() and turn the HandlerE into an http.Handler.
+//
+// As well as making handler code a little simpler, separating the ErrWriter
+// allows for common error handling amongst disparate handlers.
+//
+// The default ErrWriter writes errors that wrap an httpe.StatusError by
+// writing the status code of that error and if the status code is a client
+// error, writes the error formatted as a string. If it is not a client error,
+// it writes just the text for that status code. Errors that do not wrap an
+// httpe.StatusError are treated as httpe.ErrInternalServerError.
+//
+// Option arguments to NewHandler() allow a custom ErrWriter to be provided.
 package httpe
 
 import (
 	"net/http"
 )
 
-// HandlerE works like an HTTP.Handler with the addition of an error
-// return value. It is intended to be used with ErrWriter which handles
-// the error and turns it into an appropriate http response StatusCode
-// and Body.
+// HandlerE works like an HTTP.Handler with the addition of an error return
+// value. It is intended to be used with ErrWriter which handles the error and
+// writes an appropriate http response StatusCode and Body to the
+// ResponseWriter.
 type HandlerE interface {
 	ServeHTTPe(http.ResponseWriter, *http.Request) error
 }
@@ -40,37 +61,58 @@ func (ew ErrWriterFunc) WriteErr(w http.ResponseWriter, err error) {
 	ew(w, err)
 }
 
-// NewHandler creates a new http.HandlerFunc which calls
-// HandlerE.ServeHTTP and if it returns an error calls ErrWriter.Write
-// to create the appropriate response.
-func NewHandler(h HandlerE, ew ErrWriter) http.Handler {
+// NewHandler returns an http.Handler that calls h.ServeHTTPe and handles the
+// error returned, if any, with an ErrWriter to write the error to the
+// ResponseWriter. The default ErrWriter is httpe.WriteSafeErr but can be
+// overridden with an option passed to NewHandler.
+func NewHandler(h HandlerE, opts ...option) http.Handler {
+	o := newOptions(opts)
 	f := func(w http.ResponseWriter, r *http.Request) {
 		if err := h.ServeHTTPe(w, r); err != nil {
-			ew.WriteErr(w, err)
+			o.ew.WriteErr(w, err)
 		}
 	}
 	return http.HandlerFunc(f)
 }
 
-// NewHandlerFunc creates a new http.HandlerFunc which calls
-// HandlerFuncE and if it returns an error calls ErrWriterFunc to
-// create the appropriate response.
-func NewHandlerFunc(h HandlerFuncE, ew ErrWriterFunc) http.HandlerFunc { //nolint:interfacer
-	return NewHandler(h, ew).(http.HandlerFunc)
+// NewHandlerFunc returns an http.HandlerFunc that calls h() and handles the
+// error returned, if any, with an ErrWriter to write the error to the
+// ResponseWriter. The default ErrWriter is httpe.WriteSafeErr but can be
+// overridden with an option passed to NewHandlerFunc.
+func NewHandlerFunc(h HandlerFuncE, opts ...option) http.HandlerFunc { //nolint:interfacer
+	return NewHandler(h, opts...).(http.HandlerFunc)
 }
 
-// NewSafeHandler creates a new http.HandlerFunc which calls
-// HandlerE.ServeHTTP and if it returns an error calls WriteHTTPeErr
-// to create the appropriate response.
-func NewSafeHandler(h HandlerE) http.Handler {
-	return NewHandler(h, ErrWriterFunc(WriteSafeErr))
+type option func(*options)
+
+type options struct {
+	ew ErrWriter
 }
 
-// NewSafeHandlerFunc creates a new http.HandlerFunc which calls
-// HandlerFuncE and if it returns an error calls WriteHTTPeErr to
-// create the appropriate response.
-func NewSafeHandlerFunc(h HandlerFuncE) http.HandlerFunc { //nolint:interfacer
-	return NewSafeHandler(h).(http.HandlerFunc)
+func newOptions(opts []option) options {
+	o := options{
+		ew: ErrWriterFunc(WriteSafeErr),
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+
+// WithErrWriter returns an option to use the given ErrWriter as the ErrWriter
+// for a HandlerE.
+func WithErrWriter(ew ErrWriter) option { //nolint:golint // Do not want to export option type.
+	return func(o *options) {
+		o.ew = ew
+	}
+}
+
+// WithErrWriterFunc returns an option to use the given ErrWriterFunc as the
+// ErrWriter for a HandlerE.
+func WithErrWriterFunc(f ErrWriterFunc) option { //nolint:golint // Do not want to export option type.
+	return func(o *options) {
+		o.ew = f
+	}
 }
 
 // Chain returns a HandlerE which executes each of the HandlerFuncE

--- a/httpe/httpe_test.go
+++ b/httpe/httpe_test.go
@@ -26,38 +26,38 @@ func (*handlerE) WriteErr(w http.ResponseWriter, err error) {
 
 func TestHandler(t *testing.T) {
 	he := &handlerE{}
-	h := NewHandler(he, he)
+	h := NewHandler(he)
 	r := &http.Request{Method: http.MethodGet}
 	w := mock.ResponseWriter()
 	h.ServeHTTP(w, r)
-	require.Equal(t, errNoPost.Error(), w.LastBody)
+	require.Equal(t, http.StatusInternalServerError, w.LastStatus)
 }
 
 func TestHandlerFunc(t *testing.T) {
 	he := handlerE{}
-	h := NewHandlerFunc(he.ServeHTTPe, he.WriteErr)
+	h := NewHandlerFunc(he.ServeHTTPe)
+	r := &http.Request{Method: http.MethodGet}
+	w := mock.ResponseWriter()
+	h.ServeHTTP(w, r)
+	require.Equal(t, http.StatusInternalServerError, w.LastStatus)
+}
+
+func TestHandlerWithErrWriter(t *testing.T) {
+	he := &handlerE{}
+	h := NewHandler(he, WithErrWriter(he))
 	r := &http.Request{Method: http.MethodGet}
 	w := mock.ResponseWriter()
 	h.ServeHTTP(w, r)
 	require.Equal(t, errNoPost.Error(), w.LastBody)
 }
 
-func TestSafeHandler(t *testing.T) {
-	he := &handlerE{}
-	h := NewSafeHandler(he)
-	r := &http.Request{Method: http.MethodGet}
-	w := mock.ResponseWriter()
-	h.ServeHTTP(w, r)
-	require.Equal(t, http.StatusInternalServerError, w.LastStatus)
-}
-
-func TestSafeHandlerFunc(t *testing.T) {
+func TestHandlerFuncWithErrWriter(t *testing.T) {
 	he := handlerE{}
-	h := NewSafeHandlerFunc(he.ServeHTTPe)
+	h := NewHandlerFunc(he.ServeHTTPe, WithErrWriterFunc(he.WriteErr))
 	r := &http.Request{Method: http.MethodGet}
 	w := mock.ResponseWriter()
 	h.ServeHTTP(w, r)
-	require.Equal(t, http.StatusInternalServerError, w.LastStatus)
+	require.Equal(t, errNoPost.Error(), w.LastBody)
 }
 
 func TestChain(t *testing.T) {


### PR DESCRIPTION
Use the options pattern to unify `NewHandler` and `NewSafeHandler` (and
their `Func` siblings) so that the default is now to use `WriteSafeErr`
to write errors to the `http.ResponseWriter` and allow it to be
overridden with an option `WithErrWriter`/`WithErrWriterFunc`.

The make simple use simple, keeping a tighter but extensible API
surface.

Link: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
Link: https://commandcenter.blogspot.com/2014/01/self-referential-functions-and-design.html