### PR TITLE
httpe: Add New() function for magical chaining

### DIFF
--- a/httpe/example_new_test.go
+++ b/httpe/example_new_test.go
@@ -1,0 +1,66 @@
+package httpe_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"foxygo.at/s/httpe"
+)
+
+func ExampleNew() {
+	// Create a handler by chaining a number of other handlers and an
+	// error writer to handle any errors from those handlers.
+	handler, _ := httpe.New(corsAllowAll, httpe.Get, &api{}, errWriter)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/hello", nil)
+	handler.ServeHTTP(w, r)
+	fmt.Printf("%d %s\n", w.Code, w.Body.String()) // 200 world
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("POST", "/hello", nil)
+	handler.ServeHTTP(w, r)
+	fmt.Printf("%d %s\n", w.Code, w.Body.String()) // 405 🐈 METHOD NOT ALLOWED!!!1!
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/goodbye", nil)
+	handler.ServeHTTP(w, r)
+	fmt.Printf("%d %s\n", w.Code, w.Body.String()) // 500 🐈 NO GOODBYES!!!1!
+
+	// output:
+	// 200 world
+	// 405 🐈 METHOD NOT ALLOWED!!!1!
+	// 500 🐈 NO GOODBYES!!!1!
+}
+
+// A traditional http.Handler compatible function.
+func corsAllowAll(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+}
+
+type api struct{}
+
+// Implements httpe.HandlerE.
+func (a *api) ServeHTTPe(w http.ResponseWriter, r *http.Request) error {
+	switch r.URL.Path {
+	case "/hello":
+		fmt.Fprintf(w, "world")
+	case "/goodbye":
+		return errors.New("no goodbyes")
+	}
+	return nil
+}
+
+// Matches httpe.ErrWriterFunc.
+func errWriter(w http.ResponseWriter, err error) {
+	var se httpe.StatusError
+	if errors.As(err, &se) {
+		w.WriteHeader(se.Code())
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	fmt.Fprintf(w, "🐈 "+strings.ToUpper(err.Error())+"!!!1!")
+}

--- a/httpe/httpe_test.go
+++ b/httpe/httpe_test.go
@@ -3,6 +3,7 @@ package httpe
 import (
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"foxygo.at/s/mock"
@@ -22,6 +23,62 @@ func (*handlerE) ServeHTTPe(w http.ResponseWriter, r *http.Request) error {
 
 func (*handlerE) WriteErr(w http.ResponseWriter, err error) {
 	fmt.Fprint(w, err.Error())
+}
+
+func TestNew(t *testing.T) {
+	var handlerE HandlerE = HandlerFuncE(func(w http.ResponseWriter, _ *http.Request) error {
+		fmt.Fprintf(w, "1")
+		return nil
+	})
+	funcE := func(w http.ResponseWriter, _ *http.Request) error {
+		fmt.Fprintf(w, "2")
+		return nil
+	}
+	var handlerH http.Handler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, "3")
+	})
+	funcH := func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, "4")
+	}
+
+	h, err := New(handlerE, funcE, handlerH, funcH)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, &http.Request{})
+	require.Equal(t, "1234", w.Body.String())
+
+	f := func() { Must(handlerE, funcE, handlerH, funcH) }
+	require.NotPanics(t, f)
+}
+
+func TestNewErr(t *testing.T) {
+	ew := ErrWriterFunc(func(_ http.ResponseWriter, _ error) {})
+
+	// Test multuple ErrWriters
+	_, err := New(ew, func(_ http.ResponseWriter, _ error) {})
+	require.Error(t, err)
+
+	// Test unknown type
+	_, err = New(42)
+	require.Error(t, err)
+
+	f := func() { Must(ew, ew) }
+	require.Panics(t, f)
+}
+
+func TestNewErrWriter(t *testing.T) {
+	funcE := func(w http.ResponseWriter, _ *http.Request) error {
+		return fmt.Errorf("%w: 🐿️", ErrBadRequest)
+	}
+	ew := ErrWriterFunc(func(w http.ResponseWriter, err error) {
+		fmt.Fprint(w, "error: ", err.Error())
+	})
+
+	h, err := New(funcE, ew)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, &http.Request{})
+	require.Equal(t, "error: Bad Request: 🐿️", w.Body.String())
 }
 
 func TestHandler(t *testing.T) {


### PR DESCRIPTION
Add a `New()` function that accepts various types of parameters
representing handlers and chain them together calling them one after the
other. Each is treated as a HandlerE so can return errors. If any
handler in the chain does return an error, no further handlers in the
chain are called, and the error is passed to an ErrWriter.

One ErrWriter can be supplied in the argument list (anywhere), and that
will be used as the ErrWriter to handle errors. If none is supplied,
then the default `WriteSafeErr` is used.

The types of handlers accepted are HandlerE and http.Handler (which
includes http.HandlerFunc and HandlerFuncE), and also plain functions
that match the HandlerFunc types. Same for the ErrWriter arg - it can be
a function that matches ErrWriterFunc.

This dynamic typing makes the use when mixing http.Handler and plain
functions much nicer:

    h, err := New(authFunc, corsAllowAll, httpe.Get, handle, writeErr)

where you can mix and match the types without needing to cast to
HandlerFuncE, or adapt http.Handler into HandlerE.

Add tests and an example for the new code.