### PR TITLE
errs: Add Ignore function

### DIFF
--- a/errs/ignore.go
+++ b/errs/ignore.go
@@ -1,0 +1,9 @@
+package errs
+
+// Ignore executes nullary input function f and ignores its error return
+// value. A typical use case is ignoring errors in the defer statements:
+//
+//   defer errs.Ignore(body.Close)
+func Ignore(f func() error) {
+	_ = f()
+}

--- a/errs/ignore_test.go
+++ b/errs/ignore_test.go
@@ -1,0 +1,18 @@
+package errs
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIgnore(t *testing.T) {
+	executed := false
+	f := func() error {
+		executed = true
+		return errors.New("💥")
+	}
+	Ignore(f)
+	require.True(t, executed)
+}


### PR DESCRIPTION
Add Ignore error function to be used with defer. Ignore executes nullary
input function f and ignores its error return value. A typical use case
is ignoring errors in the defer statements:

	defer errs.Ignore(body.Close)