### PR TITLE
Add ReadJSON from file test utility

### DIFF
--- a/test/json.go
+++ b/test/json.go
@@ -1,0 +1,28 @@
+package test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// ReadJSON decodes JSON from a file into a value. If it fails to open the given
+// filename or decode the contents of the file, ReadJSON will call t.Fatal with the
+// error.
+//
+// The type of the first parameter as testing.TB allows it to be used from both
+// tests and benchmarks, passing either a *testing.T or *testing.B.
+//
+//   cfg := Config{}
+//   test.ReadJSON(t, "testdata/config.json", &cfg)
+func ReadJSON(t testing.TB, fname string, v interface{}) {
+	t.Helper()
+	f, err := os.Open(fname) //nolint:gosec
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close() //nolint:errcheck,gosec
+	if err := json.NewDecoder(f).Decode(v); err != nil {
+		t.Fatalf("cannot decode %s: %v", fname, err)
+	}
+}

--- a/test/json_test.go
+++ b/test/json_test.go
@@ -1,0 +1,45 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type MockT struct {
+	testing.TB
+	errMsg string
+}
+
+func (t *MockT) Helper() {}
+func (t *MockT) Fatal(s ...interface{}) {
+	t.errMsg = fmt.Sprintln(s...)
+}
+
+func (t *MockT) Fatalf(format string, args ...interface{}) {
+	t.errMsg = fmt.Sprintf(format, args...)
+}
+
+func TestReadJSON(t *testing.T) {
+	mt := &MockT{TB: t}
+	got := map[string]string{}
+	ReadJSON(mt, "testdata/profile.json", &got)
+	want := map[string]string{"name": "Lee Sedol", "game": "Go"}
+	require.Equal(t, want, got)
+	require.Empty(t, mt.errMsg)
+}
+
+func TestReadJSONMissingFile(t *testing.T) {
+	mt := &MockT{}
+	got := map[string]string{}
+	ReadJSON(mt, "testdata/MISSING_FILE.json", &got)
+	require.NotEmpty(t, mt.errMsg)
+}
+
+func TestReadJSONInvalidJSON(t *testing.T) {
+	mt := &MockT{}
+	got := map[string]string{}
+	ReadJSON(mt, "testdata/invalid.json", &got)
+	require.NotEmpty(t, mt.errMsg)
+}

--- a/test/testdata/invalid.json
+++ b/test/testdata/invalid.json
@@ -1,0 +1,1 @@
+{"truncate

--- a/test/testdata/profile.json
+++ b/test/testdata/profile.json
@@ -1,0 +1,4 @@
+{
+	"game": "Go",
+	"name": "Lee Sedol"
+}


### PR DESCRIPTION
Add ReadJSON from file test utility function that fails the test
immediately if the file cannot be read or parsed into the provided data
structure.

       cfg := Config{}
       test.ReadJSON(t, "testdata/config.json", &cfg)
