### PR TITLE
github: Unpin setup-go version, just use "v2"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v2.1.2
+    - uses: actions/setup-go@v2
       with:
         go-version: 1.14
     - uses: actions/checkout@v2

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -30,7 +30,7 @@ jobs:
         release_name: Release ${{ steps.bump_version.outputs.tag }}
         body_path: /tmp/commit-msg
     # Get the latest module version so pkg.go.dev updates
-    - uses: actions/setup-go@v2.1.2
+    - uses: actions/setup-go@v2
       with:
         go-version: 1.14
     - name: Update pkg.go.dev


### PR DESCRIPTION
Change the version of the setup-go action to v2 from v2.1.2. Later
versions fix problems and we want those fixes automatically. In this
case, GitHub has disables the `set-env` and `add-path` commands which
v2.1.2 used. We need a newer version. Rather than bumping to a new point
release, just use "v2". (my personal preference is for reproducible
builds, so we used a specific version, but that is not really necessary
as we can reproduce a build manually).