### PR TITLE
errs: Add Const type for creating const sentinel errors

### DIFF
--- a/errs/const.go
+++ b/errs/const.go
@@ -1,0 +1,11 @@
+package errs
+
+// Const is an Error string that can be used to create a const sentinel
+// error like `const ErrFoo = errs.Const("foo")`. As a const, the value
+// of the sentinel error cannot be changed.
+type Const string
+
+// Error returns c as a string, implementing the error interface.
+func (c Const) Error() string {
+	return string(c)
+}

--- a/errs/example_errs_test.go
+++ b/errs/example_errs_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ExampleErrorf() {
-	errInternal := errors.New("internal error")
+	const errInternal = errs.Const("internal error")
 	err := errs.Errorf("%v, caused by: %v", errInternal, io.ErrUnexpectedEOF)
 
 	fmt.Println(err)
@@ -21,7 +21,7 @@ func ExampleErrorf() {
 }
 
 func ExampleNew() {
-	errInternal := errors.New("internal error")
+	const errInternal = errs.Const("internal error")
 	err := errs.New(errInternal, io.ErrUnexpectedEOF)
 
 	fmt.Println(err)
@@ -33,7 +33,7 @@ func ExampleNew() {
 }
 
 func ExampleNoWrap() {
-	errInternal := errors.New("internal error")
+	const errInternal = errs.Const("internal error")
 	err := errs.Errorf("%v, caused by: %v", errInternal, errs.NoWrap(io.ErrUnexpectedEOF))
 
 	fmt.Println(err)


### PR DESCRIPTION
Add a type `Const` that is a string that implements the error interface.
As a string, it can be used as a const allowing for const sentinel
errors. This is not possible with the built-in `errors.New` as it
returns a struct containing a string which cannot be const.

Link: https://dave.cheney.net/2016/04/07/constant-errors